### PR TITLE
fix: Use specified (US) spelling "doc-acknowledgments"

### DIFF
--- a/combined/expectations.json
+++ b/combined/expectations.json
@@ -109,7 +109,7 @@
           },
           {
             "type": "landmark",
-            "role": "doc-acknowledgements",
+            "role": "doc-acknowledgments",
             "label": null,
             "selector": "body > div:nth-child(3) > div:nth-child(5)"
           },

--- a/combined/fixtures.html
+++ b/combined/fixtures.html
@@ -67,8 +67,8 @@
 				<p>&hellip;</p>
 			</div>
 
-			<div role="doc-acknowledgements">
-				<h2>Acknowledgements</h2>
+			<div role="doc-acknowledgments">
+				<h2>Acknowledgments</h2>
 				<p>&hellip;</p>
 			</div>
 

--- a/expectations/digital-publishing-roles.json
+++ b/expectations/digital-publishing-roles.json
@@ -35,7 +35,7 @@
         },
         {
           "type": "landmark",
-          "role": "doc-acknowledgements",
+          "role": "doc-acknowledgments",
           "label": null,
           "selector": "body > div:nth-child(3) > div:nth-child(5)"
         },

--- a/fixtures/digital-publishing-roles.html
+++ b/fixtures/digital-publishing-roles.html
@@ -29,8 +29,8 @@
 				<p>&hellip;</p>
 			</div>
 
-			<div role="doc-acknowledgements">
-				<h2>Acknowledgements</h2>
+			<div role="doc-acknowledgments">
+				<h2>Acknowledgments</h2>
 				<p>&hellip;</p>
 			</div>
 


### PR DESCRIPTION
This also changes the `<h2>` in the fixture file to match.

Fixes #1