### PR TITLE
feat: Ignore dotfiles and non-HTML files

### DIFF
--- a/lib/_forEachTest.js
+++ b/lib/_forEachTest.js
@@ -6,12 +6,16 @@ module.exports = function(fixturesDir, expectationsDir, inline, run) {
 	const files = fs.readdirSync(fixturesDir)
 
 	for (const htmlFile of files) {
-		const baseName = htmlFile.substring(0, htmlFile.length - 5)
-		const data = require(path.join(expectationsDir, baseName + '.json'))
+		const baseName = path.basename(htmlFile)
+		if (!baseName.endsWith('.html') || baseName.startsWith('.')) continue
+
+		const baseNameNoExt = baseName.slice(0, -5)
+		const data = require(
+			path.join(expectationsDir, baseNameNoExt + '.json'))
 		const html = inline
 			? fs.readFileSync(path.join(fixturesDir, htmlFile), 'utf-8')
 			: path.join(fixturesDir, htmlFile)
 
-		run(baseName, data.meta, html, data.expected)
+		run(baseNameNoExt, data.meta, html, data.expected)
 	}
 }


### PR DESCRIPTION
This helps if the user's editor saves dotfiles and they're editing
whilst also running tests.